### PR TITLE
Generate word doc with track changes

### DIFF
--- a/.github/workflows/pdf-diff.yml
+++ b/.github/workflows/pdf-diff.yml
@@ -119,7 +119,7 @@ jobs:
           path: pdfs/
           retention-days: 90
 
-      - name: Upload PDFs
+      - name: Upload Word Docs
         uses: actions/upload-artifact@v4
         if: steps.generate_files.outputs.files != '[]' # Only run if there are modified files
         with:
@@ -133,9 +133,9 @@ jobs:
           MODIFIED_FILES: ${{ steps.generate_files.outputs.files }}
         with:
           script: |
-            const { issue, repo, payload } = context;
+            const { issue, repo, payload, sha } = context;
             const run_id = process.env.GITHUB_RUN_ID;
-            const sha = payload.after
+            // const sha = payload.after
 
             // Unique identifier to find the bot's comment
             const botCommentIdentifier = '<!-- GENERATED_BY_GITHUB_ACTION_PDF_DIFF -->';
@@ -173,7 +173,7 @@ jobs:
               
               // Add a comment about the word documents
               body += "\n**Word documents**:\n"
-              body += "- The changes are also provided in a word document with 'track changes' enabled.\n"
+              body += "- The changes are also provided in a word document with track changes enabled.\n"
             }
 
             body += `\n_Last updated at ${new Date().toUTCString()} for commit ${sha.substring(0, 7)}_`;

--- a/.github/workflows/pdf-diff.yml
+++ b/.github/workflows/pdf-diff.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Fetch main branch
         run: |
           git fetch origin main
-      
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -50,7 +50,7 @@ jobs:
           echo "$MODIFIED_FILES"
 
           # Create necessary directories
-          mkdir -p old_version new_version diffs pdfs
+          mkdir -p old_version new_version diffs pdfs docx
 
           # Create a custom LaTeX template
           pandoc -D latex > default_template.tex
@@ -71,6 +71,16 @@ jobs:
             pandoc new_version/"$(basename "$FILE")" --from markdown --to latex \
             --template="$TEMPLATE" -o new_version/"$(basename "$FILE" .md)".tex
 
+            # Convert both versions to Word
+            pandoc old_version/"$(basename "$FILE")" -o old_version/"$(basename "$FILE" .md)".docx
+            pandoc new_version/"$(basename "$FILE")" -o new_version/"$(basename "$FILE" .md)".docx
+
+            # Generate Word file with tracked changes
+            pandoc --track-changes=all \
+            old_version/"$(basename "$FILE" .md)".docx \
+            new_version/"$(basename "$FILE" .md)".docx \
+            -o diffs/"$(basename "$FILE" .md)"_diff.docx
+
             # Run latexdiff with appropriate options
             latexdiff \
               --encoding=utf8 \
@@ -85,6 +95,9 @@ jobs:
 
             # Move the generated PDF to the pdfs directory
             mv diffs/"$(basename "$FILE" .md)"_diff.pdf pdfs/
+
+            # Move the generated Word doc to the docx directory
+            mv diffs/"$(basename "$FILE" .md)"_diff.docx docx/
           done
 
           if [ -z "$MODIFIED_FILES" ]; then
@@ -100,12 +113,20 @@ jobs:
 
       - name: Upload PDFs
         uses: actions/upload-artifact@v4
-        if: steps.generate_files.outputs.files != '[]'  # Only run if there are modified files
+        if: steps.generate_files.outputs.files != '[]' # Only run if there are modified files
         with:
-          name: document_changes
+          name: pdf_changes
           path: pdfs/
           retention-days: 90
-      
+
+      - name: Upload PDFs
+        uses: actions/upload-artifact@v4
+        if: steps.generate_files.outputs.files != '[]' # Only run if there are modified files
+        with:
+          name: word_changes
+          path: docx/
+          retention-days: 90
+
       - name: Comment on PR with download links
         uses: actions/github-script@v7
         env:
@@ -126,7 +147,7 @@ jobs:
             } catch (error) {
               console.error("Failed to parse modified files:", error);
             }
-            
+
             let body;
 
             if (modifiedFiles.length === 0) {
@@ -146,9 +167,13 @@ jobs:
               body += "These files expire after 90 days."
 
               // Add a commend about how to read latexdiff
-              body += "\n\n**How to read these PDFs**:\n"
+              body += "\n\n**How to read the PDFs**:\n"
               body += "- Added text is wavy underlined and blue.\n"
               body += "- Discarded text is struck out and red.\n"
+              
+              // Add a comment about the word documents
+              body += "\n**Word documents**:\n"
+              body += "- The changes are also provided in a word document with 'track changes' enabled.\n"
             }
 
             body += `\n_Last updated at ${new Date().toUTCString()} for commit ${sha.substring(0, 7)}_`;

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ GitHub has a really helpful page for getting started with
 
 1. **Use the automatically generated `_diff` PDF documents to communicate with the IRB.**
 
-   When you open a pull request that modifies any markdown file in this repository, a bot will detect those changes and generate PDF documents that highlight the changes that you have made. The bot will comment on your pull request with a link to download these "diff" documents. These diff documents are useful for interacting with the IRB and ensuring that the changes to documents in this repository match the changes approved by the IRB. The bot takes a few minutes to run, so be sure to check the update timestamp at the bottom of the comment to ensure that you have the latest version of the diff documents.
+   When you open a pull request that modifies any markdown file in this repository, a bot will detect those changes and generate documents that highlight the changes that you have made. The bot will generate change documents in both .pdf and .docx formats. The bot will comment on your pull request with a link to download these "diff" documents. These diff documents are useful for interacting with the IRB and ensuring that the changes to documents in this repository match the changes approved by the IRB. The bot takes a few minutes to run, so be sure to check the update timestamp at the bottom of the comment to ensure that you have the latest version of the diff documents.
 
 [^1]: These contributing guidelines borrow language from [pyAFQ][link_pyafq]'s excellent [contribution guide][link_pyafq_contribution_guide].
 


### PR DESCRIPTION
> [!WARNING]  
> Do not merge this yet. It is a work in progress.
> Issue to fix:
> - [ ] Fix the commit number in the comment. `payload.after` does not work anymore. But `context.sha` doesn't point to what you think it does.
> - [ ] Actually render the changes as track changes. Right now, it's just duplicating the content, once for before and once for after.

This PR edits the GitHub action to generate a word doc with track changes enabled in addition to the pdf with changes.